### PR TITLE
v8.22: R key on course page now asks confirmation before reset

### DIFF
--- a/+++ userscript.txt
+++ b/+++ userscript.txt
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         eqe fmpm - e-qe.online Auto-Advance + Inline Controls [IMPROVED]
 // @namespace    https://e-qe.online/
-// @version      8.21
+// @version      8.22
 // @description  ←→↑↓ nav • T/8 loadouts • Space/Enter check • H sidebar • F fullscreen • P pomo (persists across pages) • V copy prompt • Shift+V AI menu • S stats toggle • Arrow card nav on course • Auto-expand sections • Preset island colors • Question counter
 // @match        https://e-qe.online/*
 // @match        https://www.e-qe.online/*
@@ -66,6 +66,8 @@
         dashboardConfirmTimeout:  null,
         fullscreenExitPending:    false,
         fullscreenExitTimeout:    null,
+        resetConfirmPending:      false,
+        resetConfirmTimeout:      null,
         observerDebounce:         null,
         timerEpoch:               0
     };
@@ -616,7 +618,13 @@ a[href*="/exam/"]   .mt-auto {
         document.querySelectorAll('.eqe-card-focused').forEach(c => c.classList.remove('eqe-card-focused'));
 
         // Clamp index
-        courseFocusIndex = Math.max(0, Math.min(index, cards.length - 1));
+        const newIndex = Math.max(0, Math.min(index, cards.length - 1));
+        if (newIndex !== courseFocusIndex && state.resetConfirmPending) {
+            clearTimeout(state.resetConfirmTimeout);
+            state.resetConfirmPending = false;
+            state.resetConfirmTimeout = null;
+        }
+        courseFocusIndex = newIndex;
         const card = cards[courseFocusIndex];
         card.classList.add('eqe-card-focused');
         card.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
@@ -663,10 +671,28 @@ a[href*="/exam/"]   .mt-auto {
         if ((key === 'r' || key === 'R') && courseFocusIndex >= 0) {
             e.preventDefault(); e.stopImmediatePropagation();
             const card = cards[courseFocusIndex];
-            const resetBtn = card?.querySelector('button');
-            if (resetBtn && /reset|réinitialiser/i.test(resetBtn.textContent)) {
+            // Find reset button by SVG class or text — first <button> isn't always the reset one.
+            const resetBtn = [...(card?.querySelectorAll('button') || [])].find(b =>
+                b.querySelector('svg.lucide-rotate-ccw') ||
+                /^\s*reset\s*$|réinitialiser/i.test(b.textContent || '')
+            );
+            if (!resetBtn) {
+                showToast('No reset button on this card', 'warning');
+                return true;
+            }
+            if (state.resetConfirmPending) {
+                clearTimeout(state.resetConfirmTimeout);
+                state.resetConfirmPending = false;
+                state.resetConfirmTimeout = null;
                 resetBtn.click();
-                showToast('🔄 Reset triggered', 'info');
+                showToast('🔄 Lesson progress reset', 'success');
+            } else {
+                state.resetConfirmPending = true;
+                showToast('⚠️ Press R again to reset this lesson\'s progress', 'warning');
+                state.resetConfirmTimeout = registerTimeout(setTimeout(() => {
+                    state.resetConfirmPending = false;
+                    state.resetConfirmTimeout = null;
+                }, 3000));
             }
             return true;
         }
@@ -819,7 +845,7 @@ a[href*="/exam/"]   .mt-auto {
                     <li>${kbd('S')} : Toggle Stats Panel (course page)</li>
                     <li>${kbd('← → ↑ ↓')} (course page) : Navigate cards</li>
                     <li>${kbd('Enter')} (course page) : Open focused card</li>
-                    <li>${kbd('R')} (course page) : Reset focused card</li>
+                    <li>${kbd('R')} (course page) : Reset focused lesson progress (press twice to confirm)</li>
                     <li>📊 Button (header) : Toggle course statistics panel</li>
                 </ul>
             </div>

--- a/changelogs.md
+++ b/changelogs.md
@@ -1,5 +1,14 @@
 # Changelogs
 
+## 2026-04-25 - Version 8.22
+- Added **Reset confirmation** on course page:
+    - Pressing **`R`** on a focused lesson card now asks for confirmation instead of resetting immediately.
+    - Toast: "⚠️ Press R again to reset this lesson's progress" (3s window).
+    - Second `R` press within the window clicks the lesson's Reset button and shows "🔄 Lesson progress reset".
+- Improved **Reset button detection**: now matches the `lucide-rotate-ccw` SVG (or "Reset"/"Réinitialiser" text) instead of just the first `<button>` inside the card.
+- Pending reset state is auto-cleared when the user moves to another card (arrow keys) or after a 3s timeout.
+- Updated `shortcuts.txt` and the in-app `Shift + ?` help overlay to reflect the two-press confirmation.
+
 ## 2026-03-05 15:15 - Version 8.1
 - Updated keyboard shortcuts:
     - **Course Switcher**: Changed from `Shift + M` to **`M`**.

--- a/shortcuts.txt
+++ b/shortcuts.txt
@@ -27,6 +27,12 @@
 - **`M`** or **`9`** : Open Course Switcher (Full Module List)
 - **`1` – `9`** (While Switcher Open) : Select Module and Redirect
 
+## Course Page (`/dashboard/course/*`)
+- **`← → ↑ ↓`** : Navigate between lesson cards
+- **`Enter`** / **`Space`** : Open focused lesson
+- **`R`** : Reset focused lesson progress (press twice within 3s to confirm)
+- **`S`** : Toggle Stats Panel
+
 ## Inline Button Controls (Top Right)
 - **Loadout Button** (⭐/🏎️/📝):
     - **Click** : Cycle to next loadout


### PR DESCRIPTION
## Summary
- On `/dashboard/course/*`, pressing **R** on a focused lesson card no longer resets immediately. It now shows a 3-second confirmation toast — a second **R** press within that window actually triggers the reset.
- Improved reset-button detection: matches the `lucide-rotate-ccw` SVG (or `Reset` / `Réinitialiser` text) instead of grabbing the first `<button>` in the card, which was fragile when cards contain multiple buttons.
- Pending confirmation auto-clears when the user arrows to another card or after the 3s timeout.
- Synced `shortcuts.txt`, `changelogs.md`, and the in-app `Shift + ?` help overlay per the project's maintenance mandates.

## Test plan
- [ ] Visit `https://www.e-qe.online/dashboard/course/<id>`, focus a lesson card with arrow keys.
- [ ] Press `R` → expect toast: `⚠️ Press R again to reset this lesson's progress`. The lesson must NOT be reset yet.
- [ ] Press `R` again within 3s → expect the lesson's Reset button to fire and toast `🔄 Lesson progress reset`.
- [ ] Press `R` once, wait >3s, verify nothing happens (pending state cleared).
- [ ] Press `R` once on card A, arrow to card B, press `R` once on B → first press on B must show the warning toast (not reset), proving pending state is cleared on focus change.
- [ ] Confirm `Shift + ?` help overlay shows the updated text.

https://claude.ai/code/session_01MAKRz4F6JJerNJnpZZTEn7

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAKRz4F6JJerNJnpZZTEn7)_