### PR TITLE
Add scrape-eqe.js: per-module question-bank exporter

### DIFF
--- a/scrape-eqe.js
+++ b/scrape-eqe.js
@@ -1,0 +1,522 @@
+// ==UserScript==
+// @name         eqe scraper - e-qe.online Question Bank Exporter
+// @namespace    https://e-qe.online/
+// @version      0.1.0
+// @description  Scrape blank questions (no corrections) from a course on e-qe.online and export per-module .txt + .md files. Run on a course page, click "Scrape Course", the script auto-walks every /exam/* page in the course and downloads the result.
+// @match        https://e-qe.online/*
+// @match        https://www.e-qe.online/*
+// @grant        GM_getValue
+// @grant        GM_setValue
+// @grant        GM_deleteValue
+// @license      MIT
+// @run-at       document-idle
+// ==/UserScript==
+
+(() => {
+    'use strict';
+
+    if (window.__eqeScraperLoaded) return;
+    window.__eqeScraperLoaded = true;
+
+    // ============================================================================
+    // CONSTANTS & STATE KEYS
+    // ============================================================================
+
+    const JOB_KEY            = 'scrape_job_v1';
+    const COURSE_URL_RE      = /\/dashboard\/course\/[0-9a-f-]+/i;
+    const EXAM_URL_RE        = /\/exam\/[0-9a-f-]+/i;
+    const LABELS             = ['A', 'B', 'C', 'D', 'E'];
+
+    // Page-load grace period before we try to scrape the first question.
+    const PAGE_SETTLE_MS     = 1500;
+    // How long to wait for a question's DOM to appear after a click.
+    const QUESTION_WAIT_MS   = 8000;
+    // How often we poll the DOM while waiting for a new question.
+    const POLL_MS            = 200;
+    // Hard cap of questions per exam — guards against infinite loops if we
+    // misdetect end-of-exam.
+    const MAX_QUESTIONS_PER_EXAM = 200;
+
+    // ============================================================================
+    // SELECTORS  (mirrored from +++ userscript.txt — keep in sync)
+    // ============================================================================
+
+    const getQuestionEl = () => document.querySelector('h2');
+
+    const getAnswerButtons = () => {
+        const containers = document.querySelectorAll(
+            'div.group.relative.w-full.overflow-hidden.rounded-2xl.border'
+        );
+        return Array.from(containers).filter(c => {
+            const label = c.firstElementChild?.firstElementChild?.textContent?.trim();
+            return label && LABELS.includes(label);
+        });
+    };
+
+    const getNextBtn = () =>
+        document.querySelector('button[aria-label="Go to next question"]') ||
+        Array.from(document.querySelectorAll('button')).find(b =>
+            /next|suivant/i.test(b.textContent || '')
+        );
+
+    // ============================================================================
+    // JOB STATE  (persisted across page navigations via GM storage)
+    // ============================================================================
+    //
+    // job = {
+    //   active: true,
+    //   module: "Glandes endocrines...",
+    //   courseUrl: "https://www.e-qe.online/dashboard/course/<uuid>",
+    //   exams: [{ url, title }, ...],   // discovered on the course page
+    //   currentExamIndex: 0,
+    //   data: {                          // exam title -> scraped block
+    //     "Octobre 2024": { url, questions: [{ text, props: ["A]...","B]..."] }] }
+    //   },
+    //   lastQuestionText: null,          // for change-detection across clicks
+    //   currentExamCount: 0,             // questions captured for current exam
+    // }
+    function loadJob() {
+        try { return JSON.parse(GM_getValue(JOB_KEY, 'null')); }
+        catch { return null; }
+    }
+    function saveJob(job) { GM_setValue(JOB_KEY, JSON.stringify(job)); }
+    function clearJob()   { GM_deleteValue(JOB_KEY); }
+
+    // ============================================================================
+    // UTILITIES
+    // ============================================================================
+
+    const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+    function waitFor(predicate, timeoutMs = QUESTION_WAIT_MS, intervalMs = POLL_MS) {
+        return new Promise(resolve => {
+            const start = Date.now();
+            const tick = () => {
+                let value;
+                try { value = predicate(); } catch { value = null; }
+                if (value) return resolve(value);
+                if (Date.now() - start >= timeoutMs) return resolve(null);
+                setTimeout(tick, intervalMs);
+            };
+            tick();
+        });
+    }
+
+    function sanitizeFilename(s) {
+        return (s || 'module')
+            .replace(/[\\/:*?"<>|]+/g, '')
+            .replace(/\s+/g, ' ')
+            .trim()
+            .slice(0, 120) || 'module';
+    }
+
+    function downloadBlob(filename, content, mime = 'text/plain;charset=utf-8') {
+        const blob = new Blob([content], { type: mime });
+        const url  = URL.createObjectURL(blob);
+        const a    = document.createElement('a');
+        a.href     = url;
+        a.download = filename;
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        setTimeout(() => URL.revokeObjectURL(url), 5000);
+    }
+
+    function showToast(msg, kind = 'info') {
+        const colors = {
+            info:    '#3b82f6',
+            success: '#10b981',
+            warning: '#f59e0b',
+            error:   '#ef4444',
+        };
+        const t = document.createElement('div');
+        t.textContent = msg;
+        Object.assign(t.style, {
+            position: 'fixed',
+            top: '70px',
+            right: '20px',
+            background: colors[kind] || colors.info,
+            color: 'white',
+            padding: '10px 14px',
+            borderRadius: '10px',
+            font: '13px/1.3 system-ui,sans-serif',
+            zIndex: 2000001,
+            boxShadow: '0 8px 24px rgba(0,0,0,0.25)',
+            maxWidth: '320px',
+        });
+        document.body.appendChild(t);
+        setTimeout(() => t.remove(), 3500);
+    }
+
+    // ============================================================================
+    // QUESTION CAPTURE
+    // ============================================================================
+
+    function getCurrentQuestion() {
+        const qEl = getQuestionEl();
+        if (!qEl) return null;
+        const text = qEl.textContent.trim();
+        if (text.length < 5) return null;
+
+        const btns = getAnswerButtons();
+        if (btns.length === 0) return null;
+
+        const props = btns.map((btn, i) => {
+            const label = LABELS[i] || String(i + 1);
+            const parts = [];
+            btn.querySelectorAll('p, span').forEach(el => {
+                const t = el.textContent.trim();
+                if (t && !LABELS.includes(t) && t.length > 0) parts.push(t);
+            });
+            const propText = parts.join(' ').trim() ||
+                btn.textContent.replace(/^[A-E]\s*/, '').trim();
+            return `${label}] ${propText}`;
+        });
+
+        return { text, props };
+    }
+
+    // The exam page often shows a small heading like "Octobre 2024" or
+    // "normal 2026" near the question. We try a few selectors and fall back
+    // to "Exam <shortId>".
+    function getExamTitle(fallbackUrl) {
+        const candidates = [
+            'h1',
+            'header h2',
+            '[class*="exam"] h1',
+            '[class*="exam"] h2',
+        ];
+        for (const sel of candidates) {
+            const el = document.querySelector(sel);
+            const txt = el?.textContent?.trim();
+            if (txt && txt.length > 0 && txt.length < 80 && txt !== getQuestionEl()?.textContent?.trim()) {
+                return txt;
+            }
+        }
+        const m = (fallbackUrl || location.href).match(/\/exam\/([0-9a-f-]+)/i);
+        return m ? `Exam ${m[1].slice(0, 8)}` : 'Exam';
+    }
+
+    function getCourseModuleName() {
+        const h1 = document.querySelector('h1');
+        if (h1?.textContent?.trim()) return h1.textContent.trim();
+        const title = document.title.replace(/\s*\|.*$/, '').trim();
+        return title || 'Course';
+    }
+
+    // ============================================================================
+    // OUTPUT FORMATTING
+    // ============================================================================
+
+    function buildMarkdown(job) {
+        const lines = [];
+        lines.push(`# ${job.module}`);
+        lines.push('');
+
+        const examEntries = Object.entries(job.data);
+        for (const [examTitle, block] of examEntries) {
+            lines.push('---');
+            lines.push('');
+            lines.push(`## ${examTitle} : ${block.url}`);
+            lines.push('');
+            block.questions.forEach((q, idx) => {
+                lines.push(`### ${examTitle} Q${idx + 1}`);
+                lines.push('');
+                lines.push(q.text);
+                lines.push('');
+                q.props.forEach(p => {
+                    lines.push(p);
+                    lines.push('');
+                });
+                lines.push('');
+            });
+        }
+        return lines.join('\n').replace(/\n{3,}/g, '\n\n');
+    }
+
+    function buildPlainText(job) {
+        // .txt mirrors the .md content but without markdown markers, matching
+        // the user's spec "like in original page".
+        const lines = [];
+        lines.push(job.module);
+        lines.push('');
+
+        for (const [examTitle, block] of Object.entries(job.data)) {
+            lines.push('---');
+            lines.push('');
+            lines.push(`${examTitle} : ${block.url}`);
+            lines.push('');
+            block.questions.forEach((q, idx) => {
+                lines.push(`${examTitle} Q${idx + 1}`);
+                lines.push('');
+                lines.push(q.text);
+                lines.push('');
+                q.props.forEach(p => lines.push(p));
+                lines.push('');
+            });
+        }
+        return lines.join('\n').replace(/\n{3,}/g, '\n\n');
+    }
+
+    function exportFiles(job) {
+        const base = sanitizeFilename(job.module);
+        downloadBlob(`${base}.md`,  buildMarkdown(job),  'text/markdown;charset=utf-8');
+        downloadBlob(`${base}.txt`, buildPlainText(job), 'text/plain;charset=utf-8');
+    }
+
+    // ============================================================================
+    // COURSE PAGE: START BUTTON + EXAM DISCOVERY
+    // ============================================================================
+
+    function discoverExamLinks() {
+        const seen = new Set();
+        const exams = [];
+        document.querySelectorAll('a[href*="/exam/"]').forEach(a => {
+            const href = a.href;
+            const m = href.match(EXAM_URL_RE);
+            if (!m) return;
+            // Normalize to drop hash/query so we don't visit the same exam twice.
+            const url = href.split('#')[0].split('?')[0];
+            if (seen.has(url)) return;
+            seen.add(url);
+
+            const titleEl = a.querySelector('h3, h2, [class*="title"]');
+            const title = (titleEl?.textContent || a.textContent || '').trim() ||
+                          `Exam ${m[0].split('/').pop().slice(0, 8)}`;
+            exams.push({ url, title });
+        });
+        return exams;
+    }
+
+    function injectStartButton() {
+        if (document.getElementById('eqe-scraper-btn')) return;
+        const btn = document.createElement('button');
+        btn.id = 'eqe-scraper-btn';
+        btn.textContent = '📥 Scrape Course';
+        Object.assign(btn.style, {
+            position: 'fixed',
+            top: '70px',
+            right: '20px',
+            zIndex: 2000000,
+            padding: '10px 14px',
+            background: 'linear-gradient(135deg,#10b981 0%,#059669 100%)',
+            color: 'white',
+            border: 'none',
+            borderRadius: '10px',
+            cursor: 'pointer',
+            font: '600 13px system-ui,sans-serif',
+            boxShadow: '0 8px 24px rgba(0,0,0,0.25)',
+        });
+        btn.onclick = startScrapeFromCoursePage;
+        document.body.appendChild(btn);
+    }
+
+    function startScrapeFromCoursePage() {
+        const moduleName = getCourseModuleName();
+        const exams = discoverExamLinks();
+        if (exams.length === 0) {
+            showToast('No exam links found on this page.', 'warning');
+            return;
+        }
+        const ok = window.confirm(
+            `Scrape "${moduleName}"?\n\n` +
+            `Found ${exams.length} exam(s). The page will navigate through ` +
+            `each one and capture every question. Two files (.md, .txt) will ` +
+            `be downloaded when finished.\n\n` +
+            `Don't close the tab while scraping.`
+        );
+        if (!ok) return;
+
+        const job = {
+            active: true,
+            module: moduleName,
+            courseUrl: location.href,
+            exams,
+            currentExamIndex: 0,
+            data: {},
+            lastQuestionText: null,
+            currentExamCount: 0,
+        };
+        saveJob(job);
+        location.href = exams[0].url;
+    }
+
+    // ============================================================================
+    // EXAM PAGE: SCRAPING LOOP
+    // ============================================================================
+
+    async function runExamScrape() {
+        const job = loadJob();
+        if (!job || !job.active) return;
+
+        // Make sure we're on the exam this job expects. If the user clicked
+        // away, just abort silently — the start button on the course page
+        // can be used to retry.
+        const currentExam = job.exams[job.currentExamIndex];
+        if (!currentExam || !location.href.startsWith(currentExam.url)) return;
+
+        injectProgressHud(job);
+
+        await sleep(PAGE_SETTLE_MS);
+        const firstQuestion = await waitFor(getCurrentQuestion);
+        if (!firstQuestion) {
+            showToast(`Couldn't read questions on ${currentExam.title}. Skipping.`, 'warning');
+            return advanceToNextExam(job);
+        }
+
+        const examTitle = getExamTitle(currentExam.url);
+        if (!job.data[examTitle]) {
+            job.data[examTitle] = { url: currentExam.url, questions: [] };
+        }
+        job.lastQuestionText = null;
+        job.currentExamCount = 0;
+        saveJob(job);
+
+        let lastText = null;
+
+        for (let i = 0; i < MAX_QUESTIONS_PER_EXAM; i++) {
+            const q = await waitFor(() => {
+                const cur = getCurrentQuestion();
+                if (!cur) return null;
+                if (cur.text === lastText) return null; // wait for the new question to render
+                return cur;
+            }, QUESTION_WAIT_MS);
+
+            if (!q) break; // no more new questions — exam done
+
+            job.data[examTitle].questions.push(q);
+            job.currentExamCount = job.data[examTitle].questions.length;
+            saveJob(job);
+            updateProgressHud(job, examTitle);
+
+            lastText = q.text;
+
+            const next = getNextBtn();
+            if (!next || next.disabled || next.getAttribute('aria-disabled') === 'true') break;
+            next.click();
+            // Small breath so React can swap the DOM before our next poll.
+            await sleep(150);
+        }
+
+        await advanceToNextExam(job);
+    }
+
+    async function advanceToNextExam(job) {
+        job.currentExamIndex += 1;
+        saveJob(job);
+        if (job.currentExamIndex >= job.exams.length) {
+            // Done — generate downloads, then go back to the course page.
+            try {
+                exportFiles(job);
+                showToast(`✅ Scraped ${Object.keys(job.data).length} exam(s). Files downloading.`, 'success');
+            } catch (e) {
+                showToast(`Export failed: ${e.message}`, 'error');
+            }
+            clearJob();
+            await sleep(2500);
+            location.href = job.courseUrl;
+            return;
+        }
+        await sleep(500);
+        location.href = job.exams[job.currentExamIndex].url;
+    }
+
+    // ============================================================================
+    // PROGRESS HUD (shown while scraping is active)
+    // ============================================================================
+
+    function injectProgressHud(job) {
+        if (document.getElementById('eqe-scraper-hud')) return;
+        const hud = document.createElement('div');
+        hud.id = 'eqe-scraper-hud';
+        Object.assign(hud.style, {
+            position: 'fixed',
+            top: '70px',
+            right: '20px',
+            zIndex: 2000000,
+            padding: '12px 16px',
+            background: 'rgba(17,24,39,0.95)',
+            color: 'white',
+            borderRadius: '12px',
+            font: '500 12px system-ui,sans-serif',
+            boxShadow: '0 8px 24px rgba(0,0,0,0.4)',
+            minWidth: '240px',
+        });
+        hud.innerHTML = `
+            <div style="font-weight:700;margin-bottom:6px;">📥 Scraping…</div>
+            <div id="eqe-scraper-hud-progress" style="opacity:0.85;"></div>
+            <button id="eqe-scraper-hud-stop" style="
+                margin-top:10px;width:100%;padding:6px;border:none;border-radius:6px;
+                background:#ef4444;color:white;cursor:pointer;font:600 11px system-ui;">
+                ⏹ Stop & Discard
+            </button>
+        `;
+        document.body.appendChild(hud);
+        document.getElementById('eqe-scraper-hud-stop').onclick = () => {
+            if (window.confirm('Stop scraping and discard collected data?')) {
+                const j = loadJob();
+                clearJob();
+                showToast('Scrape stopped.', 'warning');
+                if (j) location.href = j.courseUrl;
+            }
+        };
+        updateProgressHud(job, getExamTitle(job.exams[job.currentExamIndex].url));
+    }
+
+    function updateProgressHud(job, examTitle) {
+        const el = document.getElementById('eqe-scraper-hud-progress');
+        if (!el) return;
+        const idx = job.currentExamIndex + 1;
+        const total = job.exams.length;
+        el.innerHTML =
+            `Module: <b>${escapeHtml(job.module)}</b><br>` +
+            `Exam ${idx}/${total}: <b>${escapeHtml(examTitle || '')}</b><br>` +
+            `Questions captured: <b>${job.currentExamCount || 0}</b>`;
+    }
+
+    function escapeHtml(s) {
+        return String(s).replace(/[&<>"']/g, c => (
+            { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]
+        ));
+    }
+
+    // ============================================================================
+    // ROUTING
+    // ============================================================================
+
+    function isCoursePage() { return COURSE_URL_RE.test(location.pathname); }
+    function isExamPage()   { return EXAM_URL_RE.test(location.pathname); }
+
+    function init() {
+        const job = loadJob();
+
+        if (isCoursePage()) {
+            // No active job → show the start button. If a job is somehow
+            // active on the course page (e.g. user manually navigated back),
+            // also show the button so they can restart cleanly.
+            if (job?.active) clearJob();
+            injectStartButton();
+            return;
+        }
+
+        if (isExamPage() && job?.active) {
+            runExamScrape();
+            return;
+        }
+    }
+
+    // Re-init on SPA navigation (Next.js doesn't do full reloads).
+    let lastUrl = location.href;
+    const observer = new MutationObserver(() => {
+        if (location.href !== lastUrl) {
+            lastUrl = location.href;
+            // Tear down any HUD/button from the previous route before re-init.
+            document.getElementById('eqe-scraper-btn')?.remove();
+            document.getElementById('eqe-scraper-hud')?.remove();
+            setTimeout(init, 300);
+        }
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+
+    init();
+})();


### PR DESCRIPTION
## Summary

New standalone Tampermonkey userscript (`scrape-eqe.js`) that walks every `/exam/*` link inside a course on `e-qe.online` and exports the **blank questions (no corrections)** as `.md` and `.txt` files, one pair per module.

This is separate from the main `+++ userscript.txt` and meant to be installed alongside it (or used on its own).

## How it works

1. **On a course page** (`/dashboard/course/<uuid>`): injects a green **📥 Scrape Course** button (top-right). Clicking it discovers every `a[href*="/exam/"]` on the page, asks for confirmation, then kicks off the job.
2. **Across exam pages** (`/exam/<uuid>`): the job is persisted via `GM_setValue` so it survives SPA navigations. On each exam page the script:
   - waits for the `h2` question + the A–E proposition containers to render,
   - captures `{ text, props: ["A] …", "B] …", …] }`,
   - clicks the `button[aria-label="Go to next question"]`,
   - repeats until the question stops changing or the next button is disabled,
   - then advances to the next exam URL.
3. **When all exams are done**: downloads `<Module>.md` and `<Module>.txt` and returns to the course page.

A small HUD shows live progress (`Exam i/N`, questions captured) and has a **Stop & Discard** button.

## Output format

Mirrors the format requested in the issue:

```
# Module Name

---

## Octobre 2024 : https://www.e-qe.online/exam/<uuid>

### Octobre 2024 Q1

<question text>

A] proposition A

B] proposition B

C] proposition C

D] proposition D

E] proposition E
```

Both files use the same content, the `.txt` just drops the `#`/`##`/`###` markers.

## Notes

- Selectors (`h2` for the question, `div.group.relative.w-full.overflow-hidden.rounded-2xl.border` filtered by A–E label, `button[aria-label="Go to next question"]`) are mirrored from `+++ userscript.txt` so both scripts stay consistent if the e-qe.online DOM changes.
- No corrections are captured — only the question prompt and the A–E propositions, exactly as the issue asks.
- Hard cap of 200 questions per exam guards against infinite loops if end-of-exam detection misfires.
- Zero npm deps; only `GM_getValue` / `GM_setValue` / `GM_deleteValue`.

## Test plan

- [ ] Install `scrape-eqe.js` in Tampermonkey.
- [ ] Open a course page, e.g. `https://www.e-qe.online/dashboard/course/<uuid>`, and confirm the **📥 Scrape Course** button appears.
- [ ] Click it, confirm the discovered exam count matches the cards on the page.
- [ ] Watch the HUD walk through each exam; verify questions captured per exam matches the on-screen total.
- [ ] When the run finishes, verify `<Module>.md` and `<Module>.txt` are downloaded and contain every exam (`## <Title> : <url>`) with `Q1…Qn` blocks.
- [ ] Try the **Stop & Discard** button mid-run; confirm the job state is cleared and the page returns to the course.


---
_Generated by [Claude Code](https://claude.ai/code/session_013gURanQ8323MzeC1V5VTnu)_