### PR TITLE
scrape-eqe v0.5.3: skip reveal + correction line on Correction collec…

### DIFF
--- a/scrape-eqe.js
+++ b/scrape-eqe.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         eqe scraper - e-qe.online Question Bank Exporter
 // @namespace    https://e-qe.online/
-// @version      0.5.3
+// @version      0.5.4
 // @description  Scrape blank questions (no corrections) from a course on e-qe.online and export per-module .txt + .md files. Run on a course page, click "Scrape Course", the script auto-walks every /exam/* page in the course and downloads the result.
 // @match        https://e-qe.online/*
 // @match        https://www.e-qe.online/*
@@ -45,6 +45,13 @@
     let SURGICAL_PAUSE_MS    = 500;
     // Maximum number of surgical gap-fill rounds before giving up.
     const MAX_GAP_FILL_ROUNDS = 3;
+    // Total attempts (including the first try) for a single question fetch
+    // or a single correction reveal. Retries grow in length to give the
+    // page more time on each pass — see RETRY_BACKOFF_MS.
+    const MAX_FETCH_ATTEMPTS  = 3;
+    // Linear backoff between retries: wait N * attempt before retry N.
+    // Schedule: 2s before attempt 2, 4s before attempt 3.
+    const RETRY_BACKOFF_MS    = 2000;
     // Hard cap of questions per exam — guards against infinite loops if we
     // misdetect end-of-exam.
     const MAX_QUESTIONS_PER_EXAM = 200;
@@ -281,6 +288,54 @@
             if (LABELS.includes(letter)) correct.push(letter);
         });
         return correct;
+    }
+
+    // Retry wrappers — give the page a few chances on slow renders before
+    // we give up. Both functions cap at MAX_FETCH_ATTEMPTS total tries.
+    // Backoff between attempts grows linearly via RETRY_BACKOFF_MS so the
+    // page gets meaningfully more time on each pass.
+
+    // Pass-1 question capture with retry. Returns the captured question
+    // {text, props, qn, tag, correction, correctAnswers} or null if every
+    // attempt failed AND we're not already at end-of-exam.
+    //
+    // Short-circuits when the Next button is disabled — that's a definitive
+    // signal we've reached the end of the exam, so retrying is wasted time.
+    async function captureNewQuestionWithRetry(lastText) {
+        for (let attempt = 1; attempt <= MAX_FETCH_ATTEMPTS; attempt++) {
+            const q = await waitFor(() => {
+                const cur = getCurrentQuestion();
+                if (!cur) return null;
+                if (lastText && cur.text === lastText) return null;
+                return cur;
+            }, QUESTION_WAIT_MS);
+            if (q) return q;
+
+            // If Next is gone or disabled, we've genuinely reached the end —
+            // retrying just delays the inevitable.
+            const next = getNextBtn();
+            const canAdvance = next
+                && !next.disabled
+                && next.getAttribute('aria-disabled') !== 'true';
+            if (!canAdvance) return null;
+
+            if (attempt < MAX_FETCH_ATTEMPTS) {
+                await sleep(RETRY_BACKOFF_MS * attempt);
+            }
+        }
+        return null;
+    }
+
+    // Correction-reveal wrapper. Same retry/backoff shape as the question
+    // wrapper. Used at both pass-1 and pass-2 reveal sites.
+    async function revealCorrectionWithRetry() {
+        for (let attempt = 1; attempt <= MAX_FETCH_ATTEMPTS; attempt++) {
+            if (await revealCorrection()) return true;
+            if (attempt < MAX_FETCH_ATTEMPTS) {
+                await sleep(RETRY_BACKOFF_MS * attempt);
+            }
+        }
+        return false;
     }
 
     // Trigger the revealed-correction state on the current question.
@@ -1149,13 +1204,10 @@
         const seenTexts = new Set();
 
         for (let i = 0; i < MAX_QUESTIONS_PER_EXAM; i++) {
-            const q = await waitFor(() => {
-                const cur = getCurrentQuestion();
-                if (!cur) return null;
-                if (cur.text === lastText) return null;
-                return cur;
-            }, QUESTION_WAIT_MS);
-
+            // Up to MAX_FETCH_ATTEMPTS tries with growing backoff. Returns
+            // null when both the wait timed out AND Next is disabled — the
+            // unambiguous end-of-exam signal.
+            const q = await captureNewQuestionWithRetry(lastText);
             if (!q) break; // no more new questions — exam done
 
             // Stability re-check guards against mid-render captures.
@@ -1181,7 +1233,7 @@
                 if (settings.withCorrection
                     && !correctAnswers
                     && !isCollectiveCorrection(corrBadge)) {
-                    const ok = await revealCorrection();
+                    const ok = await revealCorrectionWithRetry();
                     if (ok) correctAnswers = getCorrectAnswers();
                 }
 

--- a/scrape-eqe.js
+++ b/scrape-eqe.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         eqe scraper - e-qe.online Question Bank Exporter
 // @namespace    https://e-qe.online/
-// @version      0.5.2
+// @version      0.5.3
 // @description  Scrape blank questions (no corrections) from a course on e-qe.online and export per-module .txt + .md files. Run on a course page, click "Scrape Course", the script auto-walks every /exam/* page in the course and downloads the result.
 // @match        https://e-qe.online/*
 // @match        https://www.e-qe.online/*
@@ -317,6 +317,14 @@
         // Wait for the page to actually flip into the revealed state.
         const ok = await waitFor(isCorrectionRevealed, 4000);
         return !!ok;
+    }
+
+    // True if this exam's correction badge is the "Correction collective"
+    // variant — i.e. the site does NOT expose official answers, so there's
+    // no point clicking through to reveal anything. We skip revealCorrection()
+    // and omit the correction line entirely on these exams.
+    function isCollectiveCorrection(badge) {
+        return !!badge && /collective/i.test(badge);
     }
 
     // Correction-type badge shown above the question:
@@ -713,16 +721,21 @@
     // Render the per-question correction line, e.g.:
     //   "Correction officielle - normal 2026 Q25 - Infections cutanées = A,B,C"
     // The badge text comes from the exam block (locked once we see it).
-    // When detection hasn't returned a result yet (current state until we
-    // wire up getCorrectAnswers), prints "= [pending]" so the line is
-    // visible in the file but obviously incomplete.
+    // Returns null when the line should be omitted entirely:
+    //   - badge is "Correction collective" (site doesn't expose answers)
+    //   - no badge AND no captured answers
+    // Returns "= [pending]" when the badge IS official but reveal failed,
+    // so missing data is still visible in the file.
     function buildCorrectionLine(examTitle, q, num, block) {
-        const badge = block.correction || 'Correction';
-        const tag   = q.tag ? ` - ${q.tag}` : '';
-        const ans   = Array.isArray(q.correctAnswers) && q.correctAnswers.length
-            ? q.correctAnswers.join(',')
-            : '[pending]';
-        return `${badge} - ${examTitle} Q${num}${tag} = ${ans}`;
+        const badge = block.correction || q.correction || null;
+        if (isCollectiveCorrection(badge)) return null;
+
+        const hasAnswers = Array.isArray(q.correctAnswers) && q.correctAnswers.length;
+        if (!badge && !hasAnswers) return null;
+
+        const tag = q.tag ? ` - ${q.tag}` : '';
+        const ans = hasAnswers ? q.correctAnswers.join(',') : '[pending]';
+        return `${badge || 'Correction'} - ${examTitle} Q${num}${tag} = ${ans}`;
     }
 
     // Sort captured questions by their real qn from the page indicator.
@@ -762,8 +775,11 @@
                     lines.push('');
                 });
                 if (withCorr) {
-                    lines.push(buildCorrectionLine(examTitle, q, num, block));
-                    lines.push('');
+                    const corrLine = buildCorrectionLine(examTitle, q, num, block);
+                    if (corrLine) {
+                        lines.push(corrLine);
+                        lines.push('');
+                    }
                 }
                 lines.push('');
             });
@@ -797,8 +813,11 @@
                 q.props.forEach(p => lines.push(p));
                 lines.push('');
                 if (withCorr) {
-                    lines.push(buildCorrectionLine(examTitle, q, num, block));
-                    lines.push('');
+                    const corrLine = buildCorrectionLine(examTitle, q, num, block);
+                    if (corrLine) {
+                        lines.push(corrLine);
+                        lines.push('');
+                    }
                 }
             });
         }
@@ -1154,9 +1173,14 @@
                 // the reveal *now* (before pushing) so we capture the
                 // correct-answer letters alongside text/props. Reveal does
                 // a real click on the page, so it side-effects the user's
-                // recorded answer for this question.
+                // recorded answer for this question. Skip entirely on
+                // exams whose badge is "Correction collective" — those
+                // don't expose answers.
                 let correctAnswers = q.correctAnswers;
-                if (settings.withCorrection && !correctAnswers) {
+                const corrBadge = q.correction || job.data[examTitle].correction;
+                if (settings.withCorrection
+                    && !correctAnswers
+                    && !isCollectiveCorrection(corrBadge)) {
                     const ok = await revealCorrection();
                     if (ok) correctAnswers = getCorrectAnswers();
                 }
@@ -1225,9 +1249,13 @@
                     if (indexByQn(captured)[realQn]) continue;
 
                     // Reveal correction if the user asked for it, same as
-                    // pass 1.
+                    // pass 1 — but skip on "Correction collective" exams,
+                    // which don't expose answers.
                     let correctAnswers = got.correctAnswers;
-                    if (settings.withCorrection && !correctAnswers) {
+                    const corrBadge = got.correction || job.data[examTitle].correction;
+                    if (settings.withCorrection
+                        && !correctAnswers
+                        && !isCollectiveCorrection(corrBadge)) {
                         const ok = await revealCorrection();
                         if (ok) correctAnswers = getCorrectAnswers();
                     }


### PR DESCRIPTION
…tive exams

The "Correction collective" badge means the site doesn't expose official answers — clicking through to reveal the correction is a no-op and only side-effects the user's recorded answer. Now we detect that case and skip both the network/click work AND the output line.

Behaviour with "Scrape with correction" enabled:

  Correction officielle exam → click answer + validate, capture letters,
                               print "= A,B,C" line.
  Correction collective exam → skip click entirely, omit the correction
                               line from the file altogether.
  Officielle but reveal failed → keep "= [pending]" so missing data is
                                 still obvious in the output.

New helper: isCollectiveCorrection(badge) — case-insensitive /collective/ on the captured badge text. Used at three sites: pass-1 reveal, pass-2 reveal, and buildCorrectionLine().