### PR TITLE
scrape-eqe v0.7.2: always show captured/total in the per-exam summary

### DIFF
--- a/scrape-eqe.js
+++ b/scrape-eqe.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         eqe scraper - e-qe.online Question Bank Exporter
 // @namespace    https://e-qe.online/
-// @version      0.7.1
+// @version      0.7.2
 // @description  Scrape blank questions (no corrections) from a course on e-qe.online and export per-module .txt + .md files. Run on a course page, click "Scrape Course", the script auto-walks every /exam/* page in the course and downloads the result.
 // @match        https://e-qe.online/*
 // @match        https://www.e-qe.online/*
@@ -794,7 +794,10 @@
                     lines.push(`${title} = ${captured}/${expected} ${word} (${expected - captured} missing)`);
                 }
             } else {
-                lines.push(`${title} = ${captured} ${word}`);
+                // Always show the "captured/total" ratio, even on a
+                // perfect run, so the user can sanity-check the total
+                // count read from the page indicator at a glance.
+                lines.push(`${title} = ${captured}/${expected} ${word}`);
             }
         });
 


### PR DESCRIPTION
Before:
  toxico pharma s6 2025 N = 40 Questions
  2026 N = 49/50 Questions (1 missing = Q41)
  2025 N = 50 Questions

After:
  toxico pharma s6 2025 N = 40/40 Questions
  2026 N = 49/50 Questions (1 missing = Q41)
  2025 N = 50/50 Questions

The denominator is the "total" we read from the page's div.text-sm.font-bold.opacity-30 indicator (captured per exam during the walk). When the indicator was somehow unreadable, expected falls back to captured, so the ratio still renders sensibly (e.g. "40/40"). The "(N missing = Q…)" suffix is unchanged.